### PR TITLE
Refactor NVS commit handling

### DIFF
--- a/components/powerpal_ble/powerpal_ble.h
+++ b/components/powerpal_ble/powerpal_ble.h
@@ -128,6 +128,7 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   void decode_(const uint8_t *data, uint16_t length);
   void parse_battery_(const uint8_t *data, uint16_t length);
   void parse_measurement_(const uint8_t *data, uint16_t length);
+  void schedule_commit_(bool force = false);
  
   std::string uuid_to_device_id_(const uint8_t *data, uint16_t length);
   std::string serial_to_apikey_(const uint8_t *data, uint16_t length);


### PR DESCRIPTION
## Summary
- offload NVS commit scheduling to an App-scheduled task
- ensure NVS commit queue send is non-blocking with failure logging

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dcd8285d8833382cc1370e7a1bd24