### PR TITLE
Add HTTP upload support to Powerpal BLE component

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ The ESPHome component hasn't been merged into esphome yet, but you can use it vi
 >
 > This functionality allows you to view your energy data visualisations within the Powerpal application without ever have to bother connecting your Powerpal device to your phone ever again.
 >
-> This feature works by retrieving the Powerpal authentication information (stored on the Powerpal device itself), and collects 15 measurements before uploading them to your Powerpal Cloud.
+> This feature works by retrieving the Powerpal authentication information (stored on the Powerpal device itself), collecting measurements and uploading them directly to your Powerpal Cloud.
 >
-> This requires your energy cost per kWh in the configuration, and currently doesn't support peak/off-peak switching.
+> To enable uploads, define an [HTTP Request](https://esphome.io/components/http_request.html) component and reference it with `http_request_id`. The component uploads stored readings to the Powerpal API once per minute using your `powerpal_apikey` and `powerpal_device_id`.
+>
+> This requires your energy cost per kWh in the configuration and currently doesn't support peak/off-peak switching.
 
 #### Requirements:
 - An ESP32
@@ -39,8 +41,8 @@ external_components:
     components: [ ble_client, powerpal_ble ]
 
 # optional requirement to enable powerpal cloud uploading
-#http_request:
-#  id: powerpal_cloud_uploader
+http_request:
+  id: powerpal_cloud_uploader
 
 # optional requirement used with daily energy sensor
 time:

--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -5,6 +5,8 @@
 
 #include <nvs_flash.h>
 #include <nvs.h>
+#include <vector>
+#include <cstdio>
 
 #ifdef USE_ESP32
 namespace esphome {
@@ -170,10 +172,9 @@ void Powerpal::parse_measurement_(const uint8_t *data, uint16_t length) {
   }
 
   // 6) Cost for this interval
-  if (this->cost_sensor_) {
-    float cost = (float(pulses) / this->pulses_per_kwh_) * this->energy_cost_;
+  float cost = (float(pulses) / this->pulses_per_kwh_) * this->energy_cost_;
+  if (this->cost_sensor_)
     this->cost_sensor_->publish_state(cost);
-  }
 
   // 7) Raw pulses
   if (this->pulses_sensor_)
@@ -181,8 +182,9 @@ void Powerpal::parse_measurement_(const uint8_t *data, uint16_t length) {
 
   // 8) Watt-hours for this interval
   float wh = (float(pulses) / this->pulses_per_kwh_) * 1000.0f;
+  uint32_t wh_int = (uint32_t) roundf(wh);
   if (this->watt_hours_sensor_)
-    this->watt_hours_sensor_->publish_state((int)roundf(wh));
+    this->watt_hours_sensor_->publish_state((int)wh_int);
 
   // 9) Timestamp
   if (this->timestamp_sensor_)
@@ -199,10 +201,43 @@ void Powerpal::parse_measurement_(const uint8_t *data, uint16_t length) {
   if (this->daily_energy_sensor_)
     this->daily_energy_sensor_->publish_state(daily_kwh);
 
+  PowerpalMeasurement measurement{pulses, unix_time, wh_int, cost};
+  this->stored_measurements_.push_back(measurement);
+
   this->schedule_commit_(force_commit);
 
   if (this->daily_pulses_sensor_)
     this->daily_pulses_sensor_->publish_state(this->daily_pulses_);
+}
+
+void Powerpal::send_pending_readings_() {
+  if (this->stored_measurements_.empty() || this->http_request_ == nullptr)
+    return;
+
+  std::string payload = "[";
+  for (size_t i = 0; i < this->stored_measurements_.size(); ++i) {
+    const auto &m = this->stored_measurements_[i];
+    char buf[256];
+    snprintf(buf, sizeof(buf),
+             "{\"cost\":%.11f,\"is_peak\":false,\"pulses\":%u,\"timestamp\":%ld,\"watt_hours\":%u}",
+             m.cost, m.pulses, (long)m.timestamp, m.watt_hours);
+    if (i != 0)
+      payload += ", ";
+    payload += buf;
+  }
+  payload += "]";
+
+  char url[256];
+  snprintf(url, sizeof(url),
+           "https://readings.powerpal.net/api/v1/meter_reading/%s",
+           this->powerpal_device_id_.c_str());
+
+  std::vector<http_request::Header> headers{
+      http_request::Header{"Authorization", this->powerpal_apikey_},
+      http_request::Header{"Content-Type", "application/json"},
+  };
+
+  this->http_request_->send(http_request::HTTPMethod::HTTP_POST, url, headers, payload);
 }
 
 void Powerpal::schedule_commit_(bool force) {
@@ -223,6 +258,8 @@ void Powerpal::schedule_commit_(bool force) {
           ESP_LOGW(TAG, "NVS queue full; commit skipped");
         }
       }
+      this->send_pending_readings_();
+      this->stored_measurements_.clear();
       this->last_commit_ts_ = now_s;
       this->last_pulses_for_threshold_ = this->total_pulses_;
       ++this->nvsc_commit_count_;

--- a/components/powerpal_ble/powerpal_ble.h
+++ b/components/powerpal_ble/powerpal_ble.h
@@ -4,6 +4,7 @@
 #include "esphome/components/ble_client/ble_client.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/http_request/http_request.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 
@@ -97,6 +98,7 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   void set_device_id(std::string powerpal_device_id) { powerpal_device_id_ = powerpal_device_id; }
   void set_apikey(std::string powerpal_apikey) { powerpal_apikey_ = powerpal_apikey; }
   void set_energy_cost(double energy_cost) { energy_cost_ = energy_cost; }
+  void set_http_request(http_request::HTTPRequestComponent *http_request) { http_request_ = http_request; }
 
  protected:
   // Persisted daily pulses:
@@ -129,6 +131,7 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   void parse_battery_(const uint8_t *data, uint16_t length);
   void parse_measurement_(const uint8_t *data, uint16_t length);
   void schedule_commit_(bool force = false);
+  void send_pending_readings_();
  
   std::string uuid_to_device_id_(const uint8_t *data, uint16_t length);
   std::string serial_to_apikey_(const uint8_t *data, uint16_t length);
@@ -163,6 +166,7 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   std::string powerpal_device_id_;
   std::string powerpal_apikey_;
   double energy_cost_{0.0};
+  http_request::HTTPRequestComponent *http_request_{nullptr};
 
   uint16_t pairing_code_char_handle_ = 0x2e;
   uint16_t reading_batch_size_char_handle_ = 0x33;

--- a/components/powerpal_ble/sensor.py
+++ b/components/powerpal_ble/sensor.py
@@ -1,7 +1,7 @@
 import logging
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import sensor, ble_client, time
+from esphome.components import sensor, ble_client, time, http_request
 from esphome.const import (
     CONF_ID,
     CONF_BATTERY_LEVEL,
@@ -40,6 +40,7 @@ CONF_TIME_STAMP = "timestamp"
 CONF_PULSES = "pulses"
 CONF_COST = "cost"
 CONF_DAILY_PULSES = "daily_pulses"
+CONF_HTTP_REQUEST_ID = "http_request_id"
 
 def _validate(config):
     if CONF_DAILY_ENERGY in config and CONF_TIME_ID not in config:
@@ -127,6 +128,7 @@ CONFIG_SCHEMA = cv.All(
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_COST_PER_KWH): cv.float_range(min=0),
+            cv.Optional(CONF_HTTP_REQUEST_ID): cv.use_id(http_request.HTTPRequestComponent),
             cv.Optional(
                 CONF_POWERPAL_DEVICE_ID
             ): powerpal_deviceid,  # deviceid (optional) # if not configured, will grab from device
@@ -195,6 +197,10 @@ async def to_code(config):
 
     if CONF_COST_PER_KWH in config:
         cg.add(var.set_energy_cost(config[CONF_COST_PER_KWH]))
+
+    if CONF_HTTP_REQUEST_ID in config:
+        http = await cg.get_variable(config[CONF_HTTP_REQUEST_ID])
+        cg.add(var.set_http_request(http))
 
     if CONF_POWERPAL_DEVICE_ID in config:
         cg.add(var.set_device_id(config[CONF_POWERPAL_DEVICE_ID]))


### PR DESCRIPTION
## Summary
- wire HTTPRequestComponent into Powerpal BLE integration
- batch meter readings and POST to Powerpal cloud
- expose `http_request_id` option and document cloud upload flow
- upload pending readings on the same 60s cadence as NVS commits

## Testing
- `python -m py_compile components/powerpal_ble/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_688dde1642ac8333b71e66efeef9a276