### PR TITLE
Add logging for Powerpal upload requests

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -211,8 +211,14 @@ void Powerpal::parse_measurement_(const uint8_t *data, uint16_t length) {
 }
 
 void Powerpal::send_pending_readings_() {
-  if (this->stored_measurements_.empty() || this->http_request_ == nullptr)
+  if (this->stored_measurements_.empty()) {
+    ESP_LOGD(TAG, "No stored measurements to send");
     return;
+  }
+  if (this->http_request_ == nullptr) {
+    ESP_LOGE(TAG, "HTTP request component not configured");
+    return;
+  }
 
   std::string payload = "[";
   for (size_t i = 0; i < this->stored_measurements_.size(); ++i) {
@@ -236,6 +242,11 @@ void Powerpal::send_pending_readings_() {
       http_request::Header{"Authorization", this->powerpal_apikey_},
       http_request::Header{"Content-Type", "application/json"},
   };
+
+  ESP_LOGD(TAG, "POST %s", url);
+  ESP_LOGD(TAG, "Payload: %s", payload.c_str());
+  for (const auto &h : headers)
+    ESP_LOGD(TAG, "Header: %s: %s", h.name.c_str(), h.value.c_str());
 
   this->http_request_->send(http_request::HTTPMethod::HTTP_POST, url, headers, payload);
 }


### PR DESCRIPTION
## Summary
- add debug log messages to Powerpal HTTP upload function
- log URL, payload, and headers before sending, and warn when no data or http component missing

## Testing
- `g++ -std=c++17 -fsyntax-only components/powerpal_ble/powerpal_ble.cpp` *(fails: esphome/core/component.h: No such file or directory)*
- `python -m py_compile components/powerpal_ble/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_688dec8e040c833382868816fa6edcc0