### PR TITLE
Add log when uploading measurements

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -220,6 +220,8 @@ void Powerpal::send_pending_readings_() {
     return;
   }
 
+  ESP_LOGI(TAG, "Uploading %u stored measurements", (unsigned) this->stored_measurements_.size());
+
   std::string payload = "[";
   for (size_t i = 0; i < this->stored_measurements_.size(); ++i) {
     const auto &m = this->stored_measurements_[i];
@@ -243,8 +245,8 @@ void Powerpal::send_pending_readings_() {
       http_request::Header{"Content-Type", "application/json"},
   };
 
-  ESP_LOGD(TAG, "POST %s", url);
-  ESP_LOGD(TAG, "Payload: %s", payload.c_str());
+  ESP_LOGI(TAG, "POST %s", url);
+  ESP_LOGI(TAG, "Payload: %s", payload.c_str());
   for (const auto &h : headers)
     ESP_LOGD(TAG, "Header: %s: %s", h.name.c_str(), h.value.c_str());
 


### PR DESCRIPTION
## Summary
- log the number of stored measurements before invoking HTTP upload
- log the HTTP upload URL and JSON payload to aid debugging

## Testing
- `python -m compileall components/powerpal_ble`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_688e0fcb23788333871e881a4a8f565c