### PR TITLE
Log upload attempts even when no readings

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -217,8 +217,10 @@ void Powerpal::parse_measurement_(const uint8_t *data, uint16_t length) {
 }
 
 void Powerpal::send_pending_readings_() {
+  ESP_LOGI(TAG, "Preparing to upload %u stored measurements",
+           (unsigned) this->stored_measurements_.size());
   if (this->stored_measurements_.empty()) {
-    ESP_LOGD(TAG, "No stored measurements to send");
+    ESP_LOGI(TAG, "No stored measurements to send");
     return;
   }
   if (this->http_request_ == nullptr) {


### PR DESCRIPTION
## Summary
- Log pending upload count even when it's zero
- Leave existing URL and payload logging at info level

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ea7b4834083338f531696d94e6b83