### PR TITLE
Ensure upload interval runs

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -100,9 +100,14 @@ void Powerpal::setup() {
 
   // Schedule periodic HTTP uploads independent of NVS commits
   this->set_interval("pp_upload", COMMIT_INTERVAL_S * 1000, [this]() {
-    ESP_LOGD(TAG, "Periodic upload triggered"); 
+    ESP_LOGD(TAG, "Periodic upload triggered");
     this->send_pending_readings_();
   });
+}
+
+void Powerpal::loop() {
+  ::esphome::ble_client::BLEClientNode::loop();
+  Component::loop();
 }
 
 

--- a/components/powerpal_ble/powerpal_ble.h
+++ b/components/powerpal_ble/powerpal_ble.h
@@ -66,6 +66,7 @@ static const float kw_to_w_conversion = 1000.0;    // conversion ratio
 class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
  public:
   void setup() override;
+  void loop() override;
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;


### PR DESCRIPTION
## Summary
- Ensure Powerpal component's interval scheduler runs by calling Component::loop in new loop override

## Testing
- `esphome compile powerpalproesp.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f1eb6d6b4833384c5471bff4cecc1