### PR TITLE
Fix HTTP request component reference

### DIFF
--- a/components/powerpal_ble/powerpal_ble.h
+++ b/components/powerpal_ble/powerpal_ble.h
@@ -96,7 +96,7 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   void set_device_id(std::string powerpal_device_id) { powerpal_device_id_ = powerpal_device_id; }
   void set_apikey(std::string powerpal_apikey) { powerpal_apikey_ = powerpal_apikey; }
   void set_energy_cost(double energy_cost) { energy_cost_ = energy_cost; }
-  void set_http_request(http_request::HTTPRequestComponent *http_request) { http_request_ = http_request; }
+  void set_http_request(http_request::HttpRequestComponent *http_request) { http_request_ = http_request; }
 
  protected:
   // Persisted daily pulses:
@@ -166,7 +166,7 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   std::string powerpal_device_id_;
   std::string powerpal_apikey_;
   double energy_cost_{0.0};
-  http_request::HTTPRequestComponent *http_request_{nullptr};
+  http_request::HttpRequestComponent *http_request_{nullptr};
 
   uint16_t pairing_code_char_handle_ = 0x2e;
   uint16_t reading_batch_size_char_handle_ = 0x33;

--- a/components/powerpal_ble/sensor.py
+++ b/components/powerpal_ble/sensor.py
@@ -128,7 +128,7 @@ CONFIG_SCHEMA = cv.All(
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_COST_PER_KWH): cv.float_range(min=0),
-            cv.Optional(CONF_HTTP_REQUEST_ID): cv.use_id(http_request.HTTPRequestComponent),
+            cv.Optional(CONF_HTTP_REQUEST_ID): cv.use_id(http_request.HttpRequestComponent),
             cv.Optional(
                 CONF_POWERPAL_DEVICE_ID
             ): powerpal_deviceid,  # deviceid (optional) # if not configured, will grab from device


### PR DESCRIPTION
## Summary
- fix powerpal BLE sensor to use HttpRequestComponent
- update C++ header for HttpRequestComponent

## Testing
- `python -m py_compile components/powerpal_ble/sensor.py`
- `pytest`
- `pip install esphome` *(fails: Could not find a version that satisfies the requirement esphome)*

------
https://chatgpt.com/codex/tasks/task_e_688f294006f88333aa5bed0637a71d23