### PR TITLE
Close NVS handle on Powerpal shutdown

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -13,6 +13,13 @@ namespace powerpal_ble {
 static const char *const TAG = "powerpal_ble";
 
 
+Powerpal::~Powerpal() {
+  if (this->nvs_ok_) {
+    nvs_close(this->nvs_handle_);
+    this->nvs_ok_ = false;
+  }
+}
+
 void Powerpal::dump_config() {
   ESP_LOGCONFIG(TAG, "POWERPAL");
   LOG_SENSOR(" ", "Battery", this->battery_);

--- a/components/powerpal_ble/powerpal_ble.h
+++ b/components/powerpal_ble/powerpal_ble.h
@@ -49,6 +49,7 @@ static const float kw_to_w_conversion = 1000.0;    // conversion ratio
 class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   // class Powerpal : public esphome::ble_client::BLEClientNode, public PollingComponent {
  public:
+  ~Powerpal() override;
   void setup() override;
   // void loop() override;
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,


### PR DESCRIPTION
## Summary
- Add Powerpal destructor that closes NVS handle when initialized

## Testing
- `pip install esphome` *(fails: Could not connect to proxy)*
- `g++ -std=c++17 -c components/powerpal_ble/powerpal_ble.cpp -o /tmp/powerpal_ble.o` *(fails: esphome/core/component.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894270f05108333bc24562141f56235