### PR TITLE
Remove unused conversion constants

### DIFF
--- a/components/powerpal_ble/powerpal_ble.h
+++ b/components/powerpal_ble/powerpal_ble.h
@@ -39,13 +39,6 @@ static const espbt::ESPBTUUID POWERPAL_CHARACTERISTIC_SERIAL_UUID =
 static const espbt::ESPBTUUID POWERPAL_BATTERY_SERVICE_UUID = espbt::ESPBTUUID::from_uint16(0x180F);
 static const espbt::ESPBTUUID POWERPAL_BATTERY_CHARACTERISTIC_UUID = espbt::ESPBTUUID::from_uint16(0x2A19);
 
-
-
-static const uint8_t seconds_in_minute = 60;    // seconds
-static const float kw_to_w_conversion = 1000.0;    // conversion ratio
-
-
-
 class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   // class Powerpal : public esphome::ble_client::BLEClientNode, public PollingComponent {
  public:


### PR DESCRIPTION
## Summary
- remove unused seconds_in_minute and kw_to_w_conversion constants from powerpal_ble.h

## Testing
- `pip install esphome` *(fails: Could not find a version that satisfies the requirement esphome)*

------
https://chatgpt.com/codex/tasks/task_e_68942d80b88083339e50c5228f062272