### PR TITLE
log unexpected reading batch size length

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -333,7 +333,7 @@ void Powerpal::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gat
             }
           }
         } else {
-          // error, length should be 4
+          ESP_LOGW(TAG, "Unexpected reading_batch_size length (%d)", param->read.value_len);
         }
         break;
       }


### PR DESCRIPTION
## Summary
- warn when reading_batch_size read event returns unexpected length

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689459bf6bc483339fdeb56e11a0aedc