### PR TITLE
Log additional Powerpal BLE sensors

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -27,6 +27,11 @@ void Powerpal::dump_config() {
   LOG_SENSOR(" ", "Power", this->power_sensor_);
   LOG_SENSOR(" ", "Daily Energy", this->daily_energy_sensor_);
   LOG_SENSOR(" ", "Total Energy", this->energy_sensor_);
+  LOG_SENSOR(" ", "Cost", this->cost_sensor_);
+  LOG_SENSOR(" ", "Pulses", this->pulses_sensor_);
+  LOG_SENSOR(" ", "Watt Hours", this->watt_hours_sensor_);
+  LOG_SENSOR(" ", "Timestamp", this->timestamp_sensor_);
+  LOG_SENSOR(" ", "Daily Pulses", this->daily_pulses_sensor_);
   }
 
 void Powerpal::setup() {


### PR DESCRIPTION
## Summary
- log cost, pulse, watt-hour, timestamp, and daily pulse sensors in dump_config

## Testing
- `g++ -std=c++17 -c components/powerpal_ble/powerpal_ble.cpp` *(fails: esphome/core/component.h: No such file or directory)*
- `pip install esphome` *(fails: Could not find a version that satisfies the requirement esphome; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68945e14a9608333941af58d8252faff