### PR TITLE
Adjust cost sensor precision

### DIFF
--- a/components/powerpal_ble/sensor.py
+++ b/components/powerpal_ble/sensor.py
@@ -115,7 +115,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DAILY_PULSES): sensor.sensor_schema(),
             cv.Optional(CONF_TIME_STAMP): sensor.sensor_schema(),
             cv.Optional(CONF_COST): sensor.sensor_schema(
-                accuracy_decimals=11
+                accuracy_decimals=2
             ),
             cv.Required(CONF_PAIRING_CODE): cv.int_range(min=1, max=999999),
             cv.Required(CONF_NOTIFICATION_INTERVAL): cv.int_range(min=1, max=60),


### PR DESCRIPTION
## Summary
- limit powerpal cost sensor accuracy to 2 decimals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689465a779988333b972afde59f35662