### PR TITLE
feat: add cloud uploader toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The ESPHome component hasn't been merged into esphome yet, but you can use it vi
 >
 > This feature works by retrieving the Powerpal authentication information (stored on the Powerpal device itself), and collects 15 measurements before uploading them to your Powerpal Cloud.
 >
-> This requires your energy cost per kWh in the configuration, and currently doesn't support peak/off-peak switching.
+> Enable uploading with `powerpal_cloud_uploader` in your configuration. Optionally provide your energy `cost_per_kwh` (0 is accepted) to include cost data. Peak/off-peak switching is currently unsupported.
 
 #### Requirements:
 - An ESP32
@@ -30,7 +30,7 @@ The ESPHome component hasn't been merged into esphome yet, but you can use it vi
   - BLE MAC address (can be found on device sticker, by ESPHome BLEtracker, or by using an app like nRF Connect once you have disabled the bluetooth of all your smart devices)
   - Connection pairing pin (6 digits you input when setting up your device, also can be found printed in Powerpal info pack, or inside the Powerpal application)
   - Your Smart meter pulse rate (eg. 1000 pulses = 1kW/h)
-  - Provide your `cost_per_kwh` to enable Powerpal cloud uploading. The component will automatically send each measurement to the Powerpal servers using the API key and device id stored on your Powerpal.
+  - Set `powerpal_cloud_uploader` to `true` to enable Powerpal cloud uploading. The component will automatically send each measurement to the Powerpal servers using the API key and device id stored on your Powerpal. Optionally provide `cost_per_kwh` to upload cost data.
 
 ```yaml
 external_components:
@@ -64,7 +64,8 @@ sensor:
     notification_interval: 1 # get updates every 1 minute
     pulses_per_kwh: 1000
     time_id: homeassistant_time # daily energy still works without a time_id, but recommended to include one to properly handle daylight savings, etc.
-#    cost_per_kwh: 0.20 #dollars per kWh
+    powerpal_cloud_uploader: true # set to true to upload data to Powerpal
+#    cost_per_kwh: 0.20 # dollars per kWh (optional)
 #    powerpal_device_id: 0000abcd #optional, component will retrieve from your Powerpal if not set
 #    powerpal_apikey: 4a89e298-b17b-43e7-a0c1-fcd1412e98ef #optional, component will retrieve from your Powerpal if not set
 ```

--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -246,20 +246,17 @@ void Powerpal::parse_measurement_(const uint8_t *data, uint16_t length) {
   if (this->daily_pulses_sensor_)
     this->daily_pulses_sensor_->publish_state(this->daily_pulses_);
 
-  if (this->powerpal_device_id_.length() && this->powerpal_apikey_.length()) {
-    ESP_LOGD(TAG, "Attempting upload to Powerpal");
-    this->upload_reading_(t32, pulses, cost, wh);
-  } else {
-    ESP_LOGD(TAG, "Skipping upload: missing device ID or API key");
+  if (this->powerpal_cloud_uploader_) {
+    if (this->powerpal_device_id_.length() && this->powerpal_apikey_.length()) {
+      ESP_LOGD(TAG, "Attempting upload to Powerpal");
+      this->upload_reading_(t32, pulses, cost, wh);
+    } else {
+      ESP_LOGD(TAG, "Skipping upload: missing device ID or API key");
+    }
   }
 }
 
 void Powerpal::upload_reading_(uint32_t timestamp, uint16_t pulses, float cost, float watt_hours) {
-  if (this->energy_cost_ <= 0.0f) {
-    ESP_LOGD(TAG, "Upload skipped: invalid energy_cost %.2f", this->energy_cost_);
-    return;
-  }
-
   char url[128];
   snprintf(url, sizeof(url), "https://readings.powerpal.net/api/v1/meter_reading/%s", this->powerpal_device_id_.c_str());
 

--- a/components/powerpal_ble/powerpal_ble.h
+++ b/components/powerpal_ble/powerpal_ble.h
@@ -73,6 +73,7 @@ public:
   void set_device_id(std::string powerpal_device_id) { powerpal_device_id_ = powerpal_device_id; }
   void set_apikey(std::string powerpal_apikey) { powerpal_apikey_ = powerpal_apikey; }
   void set_energy_cost(double energy_cost) { energy_cost_ = energy_cost; }
+  void set_powerpal_cloud_uploader(bool powerpal_cloud_uploader) { powerpal_cloud_uploader_ = powerpal_cloud_uploader; }
 
  protected:
   // Persisted daily pulses:
@@ -126,6 +127,7 @@ public:
   std::string powerpal_device_id_;
   std::string powerpal_apikey_;
   double energy_cost_{0.0};
+  bool powerpal_cloud_uploader_{false};
 
   uint16_t pairing_code_char_handle_ = 0x2e;
   uint16_t reading_batch_size_char_handle_ = 0x33;

--- a/components/powerpal_ble/sensor.py
+++ b/components/powerpal_ble/sensor.py
@@ -32,6 +32,7 @@ CONF_PAIRING_CODE = "pairing_code"
 CONF_NOTIFICATION_INTERVAL = "notification_interval"
 CONF_PULSES_PER_KWH = "pulses_per_kwh"
 CONF_COST_PER_KWH = "cost_per_kwh"
+CONF_POWERPAL_CLOUD_UPLOADER = "powerpal_cloud_uploader"
 CONF_POWERPAL_DEVICE_ID = "powerpal_device_id"
 CONF_POWERPAL_APIKEY = "powerpal_apikey"
 CONF_DAILY_ENERGY = "daily_energy"
@@ -127,6 +128,7 @@ CONFIG_SCHEMA = cv.All(
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_COST_PER_KWH): cv.float_range(min=0),
+            cv.Optional(CONF_POWERPAL_CLOUD_UPLOADER, default=False): cv.boolean,
             cv.Optional(
                 CONF_POWERPAL_DEVICE_ID
             ): powerpal_deviceid,  # deviceid (optional) # if not configured, will grab from device
@@ -195,6 +197,8 @@ async def to_code(config):
 
     if CONF_COST_PER_KWH in config:
         cg.add(var.set_energy_cost(config[CONF_COST_PER_KWH]))
+
+    cg.add(var.set_powerpal_cloud_uploader(config[CONF_POWERPAL_CLOUD_UPLOADER]))
 
     if CONF_POWERPAL_DEVICE_ID in config:
         cg.add(var.set_device_id(config[CONF_POWERPAL_DEVICE_ID]))


### PR DESCRIPTION
## Summary
- allow setting `powerpal_cloud_uploader` in YAML to control Powerpal cloud uploads
- permit uploads even when `cost_per_kwh` is zero and document optional cost

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68955ca846fc833380aaf1f370a2ff27