### PR TITLE
Improve Powerpal upload error handling

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -291,14 +291,18 @@ void Powerpal::upload_reading_(uint32_t timestamp, uint16_t pulses, float cost, 
   esp_http_client_set_method(client, HTTP_METHOD_POST);
   esp_http_client_set_header(client, "Authorization", this->powerpal_apikey_.c_str());
   esp_http_client_set_header(client, "Content-Type", "application/json");
-  esp_http_client_set_header(client, "Accept", "");
   esp_http_client_set_post_field(client, payload, strlen(payload));
 
   esp_err_t err = esp_http_client_perform(client);
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "Upload to Powerpal failed: %s", esp_err_to_name(err));
   } else {
-    ESP_LOGV(TAG, "Uploaded reading to Powerpal");
+    int status = esp_http_client_get_status_code(client);
+    if (status < 200 || status >= 300) {
+      ESP_LOGW(TAG, "Upload to Powerpal failed, status: %d", status);
+    } else {
+      ESP_LOGV(TAG, "Uploaded reading to Powerpal (status %d)", status);
+    }
   }
   esp_http_client_cleanup(client);
 }


### PR DESCRIPTION
## Summary
- Skip sending an empty Accept header when uploading readings
- Log HTTP status and treat non-2xx responses as failures

## Testing
- `g++ -std=c++17 -fsyntax-only components/powerpal_ble/powerpal_ble.cpp` *(fails: esphome/core/component.h: No such file or directory)*
- `python -m py_compile components/powerpal_ble/__init__.py components/powerpal_ble/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_6896bcbeee0c8333a74811208a64322e