### PR TITLE
Fix root CA certificate format

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -17,8 +17,7 @@ namespace powerpal_ble {
 static const char *const TAG = "powerpal_ble";
 
 // Root CA certificate for readings.powerpal.net (Let's Encrypt ISRG Root X1)
-static const char powerpal_root_ca_pem[] = R"EOF(
------BEGIN CERTIFICATE-----
+static const char powerpal_root_ca_pem[] = R"EOF(-----BEGIN CERTIFICATE-----
 MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
 TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
 cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4


### PR DESCRIPTION
## Summary
- Ensure embedded root certificate begins with PEM header without a leading newline to avoid TLS parse errors

## Testing
- `python -m py_compile components/powerpal_ble/__init__.py components/powerpal_ble/sensor.py`
- `g++ -fsyntax-only components/powerpal_ble/powerpal_ble.cpp` *(fails: esphome/core/component.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896e7d592fc8333b342dfc5470c0386