### PR TITLE
Fix Powerpal root CA certificate length

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -302,7 +302,7 @@ void Powerpal::upload_reading_(uint32_t timestamp, uint16_t pulses, float cost, 
   ESP_LOGD(TAG, "Upload URL: %s", url);
   ESP_LOGD(TAG, "Upload JSON: %s", payload);
 
-  size_t ca_cert_len = strlen(powerpal_root_ca_pem);
+  size_t ca_cert_len = strlen(powerpal_root_ca_pem) + 1;  // include null terminator
   ESP_LOGD(TAG, "CA cert length: %u, begins with: %.30s",
            static_cast<unsigned>(ca_cert_len), powerpal_root_ca_pem);
 


### PR DESCRIPTION
## Summary
- include terminating null byte in root CA certificate length so esp-idf parses it correctly

## Testing
- `g++ -c components/powerpal_ble/powerpal_ble.cpp` *(fails: esphome/core/component.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896eff310908333bd0c52013b39d7d7