### PR TITLE
Fix connection checks for Powerpal BLE component

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -134,7 +134,7 @@ void Powerpal::schedule_reconnect_() {
     if (this->parent_ == nullptr)
       return;
 
-    if (this->parent_->is_connected()) {
+    if (this->parent_->connected) {
       ESP_LOGV(TAG, "[%s] Reconnect timer fired but already connected", this->parent_->address_str().c_str());
       return;
     }
@@ -149,7 +149,7 @@ void Powerpal::attempt_subscription_(uint32_t delay_ms) {
     if (this->parent_ == nullptr)
       return;
 
-    if (!this->parent_->is_connected()) {
+    if (!this->parent_->connected) {
       ESP_LOGV(TAG, "[%s] Not connected, waiting before attempting resubscribe",
                this->parent_->address_str().c_str());
       return;


### PR DESCRIPTION
## Summary
- update the reconnect timer and handshake retry logic to use the BLE client `connected` flag
- remove calls to the non-existent `is_connected()` helper

## Testing
- `esphome compile powerpalproesp.yaml` *(fails: `esphome`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca22e65c948333a2a29b005ac14d78