### PR TITLE
Remove obsolete BLEClient callbacks

### DIFF
--- a/components/powerpal_ble/powerpal_ble.cpp
+++ b/components/powerpal_ble/powerpal_ble.cpp
@@ -294,14 +294,6 @@ void Powerpal::handle_disconnect_() {
   this->schedule_reconnect_();
 }
 
-void Powerpal::on_connect() {
-  this->handle_connect_();
-}
-
-void Powerpal::on_disconnect() {
-  this->handle_disconnect_();
-}
-
 
 std::string Powerpal::pkt_to_hex_(const uint8_t *data, uint16_t len) {
   std::string ret;

--- a/components/powerpal_ble/powerpal_ble.h
+++ b/components/powerpal_ble/powerpal_ble.h
@@ -46,8 +46,6 @@ public:
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
-  void on_connect();
-  void on_disconnect();
   void dump_config() override;
   // float get_setup_priority() const override { return setup_priority::DATA; }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }


### PR DESCRIPTION
## Summary
- drop the unused `on_connect`/`on_disconnect` callbacks from the Powerpal BLE client node
- rely on the existing GATTC event handler for connection lifecycle management to avoid API mismatches with newer ESPHome releases

## Testing
- not run (environment-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ca28a59d3483338f2a7d42ad693a1c