### PR TITLE
Fix Powerpal BLE reconnect helpers build regression

### DIFF
--- a/components/powerpal_ble/powerpal_ble.h
+++ b/components/powerpal_ble/powerpal_ble.h
@@ -115,12 +115,21 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   void decode_(const uint8_t *data, uint16_t length);
   void parse_battery_(const uint8_t *data, uint16_t length);
   void parse_measurement_(const uint8_t *data, uint16_t length);
- 
+
   std::string uuid_to_device_id_(const uint8_t *data, uint16_t length);
   std::string serial_to_apikey_(const uint8_t *data, uint16_t length);
 
+  void request_subscription_(const char *trigger_reason);
+  void reset_connection_state_();
+  void handle_connect_();
+  void handle_disconnect_(const char *reason);
+
 
   bool authenticated_;
+  bool pending_subscription_{false};
+  bool subscription_in_progress_{false};
+  bool subscription_retry_scheduled_{false};
+  bool reconnect_pending_{false};
 
   sensor::Sensor *battery_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
@@ -137,6 +146,7 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   optional<time::RealTimeClock *> time_{};
 #endif
   uint16_t day_of_last_measurement_{0};
+  uint32_t last_measurement_timestamp_s_{0};
 
   uint8_t pairing_code_[4];
   uint8_t reading_batch_size_[4] = {0x01, 0x00, 0x00, 0x00};
@@ -150,15 +160,15 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   std::string powerpal_apikey_; 
   double energy_cost_;
 
-  uint16_t pairing_code_char_handle_ = 0x2e;
-  uint16_t reading_batch_size_char_handle_ = 0x33;
-  uint16_t measurement_char_handle_ = 0x14;
+  uint16_t pairing_code_char_handle_{0};
+  uint16_t reading_batch_size_char_handle_{0};
+  uint16_t measurement_char_handle_{0};
 
-  uint16_t battery_char_handle_ = 0x10;
-  uint16_t led_sensitivity_char_handle_ = 0x25;
-  uint16_t firmware_char_handle_ = 0x3b;
-  uint16_t uuid_char_handle_ = 0x28;
-  uint16_t serial_number_char_handle_ = 0x2b;
+  uint16_t battery_char_handle_{0};
+  uint16_t led_sensitivity_char_handle_{0};
+  uint16_t firmware_char_handle_{0};
+  uint16_t uuid_char_handle_{0};
+  uint16_t serial_number_char_handle_{0};
 };
 
 }  


### PR DESCRIPTION
## Summary
- hook the connection-state helpers into the GATTC open/disconnect events and guard against missing BLE clients before scheduling reconnects
- delay subscription retries until the BLE client is connected so characteristic writes are only issued once handles are ready
- keep the per-connection measurement bookkeeping reset inside the internal helpers used on every reconnect

## Testing
- not run (esphome)

------
https://chatgpt.com/codex/tasks/task_e_68caa202b6c88333b98aa7f05b639048