### PR TITLE
Adapt Powerpal BLE client to updated BLE API

### DIFF
--- a/components/powerpal_ble/powerpal_ble.h
+++ b/components/powerpal_ble/powerpal_ble.h
@@ -66,8 +66,8 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
-  void on_connect() override;
-  void on_disconnect() override;
+  void on_connect();
+  void on_disconnect();
   void dump_config() override;
   // float get_setup_priority() const override { return setup_priority::DATA; }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
@@ -130,6 +130,7 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   bool subscription_in_progress_{false};
   bool subscription_retry_scheduled_{false};
   bool reconnect_pending_{false};
+  bool client_connected_{false};
 
   sensor::Sensor *battery_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};


### PR DESCRIPTION
## Summary
- stop overriding the removed BLEClient::on_connect/on_disconnect hooks and call the handlers from the GATTC open/disconnect events instead
- keep track of the client connection state internally so the reconnection timer no longer depends on the removed BLEClient::is_connected() helper

## Testing
- esphome compile powerpalproesp.yaml *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4ed173e083339275280286e9aaef